### PR TITLE
Moves to 0.11.x, goes back to frameless windows

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
   "window": {
     "title": "Raven",
     "toolbar": false,
-    "frame": true,
+    "frame": false,
     "width": 800,
     "height": 700,
     "min_width": 480,

--- a/source/styles/screen.styl
+++ b/source/styles/screen.styl
@@ -242,16 +242,11 @@ input, textarea {
     height: 32px
     text-align: center
     line-height: 32px
-    opacity: 0
-    top: -100px
-    transition: color 250ms ease-in-out, opacity 250ms ease-in-out, trasform 250ms ease-in-out, top 150ms ease-in
+    top: 10px
+    transition: color 250ms ease-in-out
 
     &:hover {
         color: base-font-colour
-    }
-    .fullscreen & {
-        top: 10px
-        opacity: 1
     }
 }
 

--- a/tools/build.js
+++ b/tools/build.js
@@ -5,7 +5,7 @@ var platform = path.join.bind(path, path.join(__dirname, '..', 'platform'))
 var nw = new NwBuilder({
   files: './dist/app/**',
   platforms: ['win', 'linux32', 'linux64', 'osx'],
-  version: '0.8.6',
+  version: '0.11.3',
   buildDir: 'dist',
   macIcns: platform('osx/raven.icns'),
   winIco: platform('windows/raven.ico')


### PR DESCRIPTION
Since https://github.com/rogerwang/node-webkit/issues/1669 was fixed, we
can use 0.11.x again. Some speed up with CSS rendering, and frameless
windows with draggable regions work again.